### PR TITLE
화면 경로 정의 및 NavHostController 만들어서 화면 이동 구현

### DIFF
--- a/app/src/main/java/com/sju/alom/AlomScreen.kt
+++ b/app/src/main/java/com/sju/alom/AlomScreen.kt
@@ -37,7 +37,12 @@ fun AlomApp(
             modifier = modifier.padding(innerPadding),
         ) {
             composable(route = AlomScreen.Login.name) {
-                LoginScreen()
+                LoginScreen(
+                    onLoginButtonClicked = { studentId ->
+                        viewModel.setStudentId(studentId)
+                        navController.navigate(AlomScreen.Attendance.name)
+                    },
+                )
             }
             composable(route = AlomScreen.Attendance.name) {
                 AttendanceScreen()

--- a/app/src/main/java/com/sju/alom/AlomScreen.kt
+++ b/app/src/main/java/com/sju/alom/AlomScreen.kt
@@ -1,20 +1,47 @@
 package com.sju.alom
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.sju.alom.ui.AttendanceScreen
+import com.sju.alom.ui.LoginScreen
+import com.sju.alom.ui.LoginViewModel
 
 enum class AlomScreen(@StringRes val title: Int) {
-//    Login(title = "Login"),
-//    Attendance(title = "Attendance")
+    Login(title = R.string.route_login),
+    Attendance(title = R.string.route_attendance),
 }
 
 @Composable
 fun AlomApp(
     modifier: Modifier = Modifier,
-    navController: NavHostController = rememberNavController()
+    viewModel: LoginViewModel = viewModel(),
+    navController: NavHostController = rememberNavController(),
 ) {
+    val navController = rememberNavController()
 
+    Scaffold() { innerPadding ->
+        val uiState by viewModel.uiState.collectAsState()
+        NavHost(
+            navController = navController,
+            startDestination = AlomScreen.Login.name,
+            modifier = modifier.padding(innerPadding),
+        ) {
+            composable(route = AlomScreen.Login.name) {
+                LoginScreen()
+            }
+            composable(route = AlomScreen.Attendance.name) {
+                AttendanceScreen()
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/sju/alom/data/LoginUiState.kt
+++ b/app/src/main/java/com/sju/alom/data/LoginUiState.kt
@@ -1,5 +1,5 @@
 package com.sju.alom.data
 
 data class LoginUiState(
-    val studentId: Int = 0,
+    val inputStudentId: String = "",
 )

--- a/app/src/main/java/com/sju/alom/data/LoginUiState.kt
+++ b/app/src/main/java/com/sju/alom/data/LoginUiState.kt
@@ -1,0 +1,5 @@
+package com.sju.alom.data
+
+data class LoginUiState(
+    val studentId: Int = 0,
+)

--- a/app/src/main/java/com/sju/alom/ui/LoginScreen.kt
+++ b/app/src/main/java/com/sju/alom/ui/LoginScreen.kt
@@ -14,10 +14,8 @@ import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,8 +23,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
-fun LoginScreen() {
-    var text by remember { mutableStateOf("") }
+fun LoginScreen(
+    onLoginButtonClicked: (String) -> Unit,
+) {
+    val textState = remember { mutableStateOf("") }
     val checkedState = remember { mutableStateOf(true) }
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -42,8 +42,8 @@ fun LoginScreen() {
             ) {
                 Text("학번")
                 OutlinedTextField(
-                    value = text,
-                    onValueChange = { text = it },
+                    value = textState.value,
+                    onValueChange = { textValue -> textState.value = textValue },
                     label = { Text("ex)18011642") },
                 )
             }
@@ -66,7 +66,7 @@ fun LoginScreen() {
                 modifier = Modifier.fillMaxWidth().padding(top = 80.dp),
                 contentPadding = PaddingValues(16.dp),
                 onClick = {
-                    // 로그인 로직 실행
+                    onLoginButtonClicked(textState.value)
                 },
             ) {
                 Text(
@@ -81,5 +81,5 @@ fun LoginScreen() {
 @Preview
 @Composable
 fun LoginPreview() {
-    LoginScreen()
+    LoginScreen(onLoginButtonClicked = {})
 }

--- a/app/src/main/java/com/sju/alom/ui/LoginScreen.kt
+++ b/app/src/main/java/com/sju/alom/ui/LoginScreen.kt
@@ -45,6 +45,7 @@ fun LoginScreen(
                     value = textState.value,
                     onValueChange = { textValue -> textState.value = textValue },
                     label = { Text("ex)18011642") },
+                    singleLine = true,
                 )
             }
 

--- a/app/src/main/java/com/sju/alom/ui/LoginViewModel.kt
+++ b/app/src/main/java/com/sju/alom/ui/LoginViewModel.kt
@@ -5,9 +5,18 @@ import com.sju.alom.data.LoginUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 class LoginViewModel : ViewModel() {
 
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
+
+    fun setStudentId(studentId: String) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                inputStudentId = studentId,
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/sju/alom/ui/LoginViewModel.kt
+++ b/app/src/main/java/com/sju/alom/ui/LoginViewModel.kt
@@ -1,0 +1,13 @@
+package com.sju.alom.ui
+
+import androidx.lifecycle.ViewModel
+import com.sju.alom.data.LoginUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class LoginViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LoginUiState())
+    val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">alom</string>
+    <string name="route_login">login</string>
+    <string name="route_attendance">attendance</string>
 </resources>


### PR DESCRIPTION
# 작업 내용
- 화면 경로 정의
- NavHostController 만들어서 화면 이동 구현

# 동작 화면
![Apr-28-2023 00-57-55](https://user-images.githubusercontent.com/39687846/234919131-ec23547b-8b4a-4ec3-bd30-6a8e80514bfd.gif)

# 관련 이슈
- 없음

# 추후 계획
- 파이어베이스 연동해서 아롬 회원인지 아닌지 구분하는 로직
- TextField maxLine 1줄로 설정 및 숫자만 입력하도록 변경
- DataStore 이용해서 자동로그인 로직 구현